### PR TITLE
[✨Feat] 전체적인 앱의 UI 디자인 변경

### DIFF
--- a/Selterview/Selterview/Sources/Extension/View+.swift
+++ b/Selterview/Selterview/Sources/Extension/View+.swift
@@ -16,24 +16,8 @@ extension View {
 		self.modifier(LoadingModifier(isLoading: isLoading))
 	}
 	
-	func roundedStyle(maxWidth: CGFloat, maxHeight: CGFloat, radius: CGFloat?, font: Font?, backgroundColor: Color) -> some View {
-		self.modifier(RoundedModifier(maxWidth: maxWidth, maxHeight: maxHeight, radius: radius, font: font, backgroundColor: backgroundColor))
-	}
-	
-	func roundedStyle(maxWidth: CGFloat, maxHeight: CGFloat, font: Font?, backgroundColor: Color) -> some View {
-		self.modifier(RoundedModifier(maxWidth: maxWidth, maxHeight: maxHeight, font: font, backgroundColor: backgroundColor))
-	}
-	
-	func roundedStyle(maxWidth: CGFloat, maxHeight: CGFloat, radius: CGFloat?, backgroundColor: Color) -> some View {
-		self.modifier(RoundedModifier(maxWidth: maxWidth, maxHeight: maxHeight, radius: radius, backgroundColor: backgroundColor))
-	}
-	
-	func roundedStyle(maxWidth: CGFloat, maxHeight: CGFloat, backgroundColor: Color) -> some View {
-		self.modifier(RoundedModifier(maxWidth: maxWidth, maxHeight: maxHeight, backgroundColor: backgroundColor))
-	}
-	
-	func roundedStyle(alignment: Alignment?, maxWidth: CGFloat, minHeight: CGFloat?, maxHeight: CGFloat, radius: CGFloat?, font: Font?, foregroundColor: Color?, backgroundColor: Color, borderColor: Color?) -> some View {
-		self.modifier(RoundedModifier(alignment: alignment, maxWidth: maxWidth, minHeight: minHeight, maxHeight: maxHeight, radius: radius, font: font, foregroundColor: foregroundColor, backgroundColor: backgroundColor, borderColor: borderColor))
+	func roundedStyle(alignment: Alignment = .center, radius: CGFloat = 10, font: Font = .defaultMidiumFont(.body), foregroundColor: Color = .primary, backgroundColor: Color = .clear, borderColor: Color = .clear) -> some View {
+		self.modifier(RoundedModifier(alignment: alignment, radius: radius, font: font, foregroundColor: foregroundColor, backgroundColor: backgroundColor, borderColor: borderColor))
 	}
 	
 	func showToastView(isShowToast: Binding<Bool>, message: Binding<String>) -> some View {

--- a/Selterview/Selterview/Sources/Extension/View+.swift
+++ b/Selterview/Selterview/Sources/Extension/View+.swift
@@ -12,8 +12,8 @@ extension View {
 		self.modifier(ErrorAlertModifier(isPresented: showAlert, message: message))
 	}
 	
-	func showLoadingView(isLoading: Binding<Bool>) -> some View {
-		self.modifier(LoadingModifier(isLoading: isLoading))
+	func showLoadingView(isLoading: Binding<Bool>, loadingMassage: String) -> some View {
+		self.modifier(LoadingModifier(isLoading: isLoading, loadingMassage: loadingMassage))
 	}
 	
 	func roundedStyle(alignment: Alignment = .center, radius: CGFloat = 10, font: Font = .defaultMidiumFont(.body), foregroundColor: Color = .primary, backgroundColor: Color = .clear, borderColor: Color = .clear) -> some View {

--- a/Selterview/Selterview/Sources/Presentation/Common/Modifier/LoadingModifier.swift
+++ b/Selterview/Selterview/Sources/Presentation/Common/Modifier/LoadingModifier.swift
@@ -10,11 +10,13 @@ import SwiftUI
 struct LoadingModifier: ViewModifier {
 	@Binding var isLoading: Bool
 	
+	let loadingMassage: String
+	
 	func body(content: Content) -> some View {
 		ZStack(alignment: .leading) {
 			content
 			if isLoading {
-				SkeletonView(isLoading: isLoading)
+				SkeletonView(loadingMassage: loadingMassage, isLoading: isLoading)
 			}
 		}
 		.frame(maxWidth: .infinity, maxHeight: 150)

--- a/Selterview/Selterview/Sources/Presentation/Common/Modifier/RoundedModifier.swift
+++ b/Selterview/Selterview/Sources/Presentation/Common/Modifier/RoundedModifier.swift
@@ -8,29 +8,26 @@
 import SwiftUI
 
 struct RoundedModifier: ViewModifier {
-	var alignment: Alignment?
-	var maxWidth: CGFloat
-	var minHeight: CGFloat?
-	var maxHeight: CGFloat
-	var radius: CGFloat?
-	var font: Font?
-	var foregroundColor: Color?
+	var alignment: Alignment
+	var radius: CGFloat
+	var font: Font
+	var foregroundColor: Color
 	var backgroundColor: Color
 	var borderColor: Color?
 	
 	func body(content: Content) -> some View {
 		ZStack {
-			RoundedRectangle(cornerRadius: radius ?? 10, style: .continuous)
+			RoundedRectangle(cornerRadius: radius, style: .continuous)
 				.fill(backgroundColor)
-				.frame(maxWidth: maxWidth, minHeight: minHeight ?? 0, maxHeight: maxHeight, alignment: alignment ?? .center)
+				.frame(alignment: alignment)
 				.overlay(
-					RoundedRectangle(cornerRadius: radius ?? 10)
+					RoundedRectangle(cornerRadius: radius)
 						.stroke(borderColor ?? Color.clear, lineWidth: 1)
 				)
 			content
-				.frame(maxWidth: maxWidth, minHeight: minHeight ?? 0, maxHeight: maxHeight, alignment: alignment ?? .center)
-				.font(font ?? .title)
-				.foregroundStyle(foregroundColor ?? .white)
+				.frame(alignment: alignment)
+				.font(font)
+				.foregroundStyle(foregroundColor)
 				.lineSpacing(5)
 				.padding(10)
 		}

--- a/Selterview/Selterview/Sources/Presentation/Common/Modifier/ToastModifier.swift
+++ b/Selterview/Selterview/Sources/Presentation/Common/Modifier/ToastModifier.swift
@@ -34,7 +34,7 @@ struct ToastModifier: ViewModifier {
 							isShowToast = false
 						}
 					}
-					.roundedStyle(maxWidth: .infinity, maxHeight: 50, font: .defaultMidiumFont(.body), backgroundColor: .textBackgroundLightGray)
+					.roundedStyle(font: .defaultMidiumFont(.body), backgroundColor: .textBackgroundLightGray)
 					.padding(20)
 				}
 			}

--- a/Selterview/Selterview/Sources/Presentation/Common/View/SkeletonView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Common/View/SkeletonView.swift
@@ -9,12 +9,15 @@ import Foundation
 import SwiftUI
 
 struct SkeletonView: View {
+	let loadingMassage: String
 	let isLoading: Bool
 
 	var body: some View {
 		ZStack {
 			if isLoading {
 				VStack(alignment: .leading, spacing: 8) {
+					Text(loadingMassage)
+						.foregroundStyle(.gray.opacity(0.5))
 					SkeletonBar(width: 250)
 					SkeletonBar(width: 200)
 					SkeletonBar(width: 150)

--- a/Selterview/Selterview/Sources/Presentation/Main/View/AddOptionView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/AddOptionView.swift
@@ -13,37 +13,45 @@ struct AddOptionView: View {
 	
 	var body: some View {
 		WithViewStore(store, observe: \.self) { viewStore in
-			GeometryReader { geometry in
-				let totalPadding: CGFloat = 150
-				let squareSize = max((geometry.size.width - totalPadding) / 2, 50)
-				VStack {
-					Spacer()
-					HStack {
-						Spacer()
-						Button(action: {
-							viewStore.send(.didSelectAddOption(.url))
-						}, label: {
-							Text("링크로 추가하기")
-								.frame(width: squareSize, height: squareSize)
+			ZStack {
+				HStack(spacing: 20) {
+					Button(action: {
+						viewStore.send(.didSelectAddOption(.url))
+					}, label: {
+						ZStack {
+							Circle()
+								.foregroundStyle(Color.clear)
+								.overlay(content: {
+									Circle()
+										.stroke(Color.accentTextColor, lineWidth: 2)
+								})
+							Text("링크로\n추가하기")
 								.font(.defaultMidiumFont(.title))
-						})
-						.tint(.accentTextColor)
-						.buttonStyle(.bordered)
-						Spacer()
-						Button(action: {
-							viewStore.send(.didSelectAddOption(.userDefined))
-						}, label: {
-							Text("직접 추가하기")
-								.frame(width: squareSize, height: squareSize)
+								.tint(.accentTextColor)
+						}
+					})
+					Button(action: {
+						viewStore.send(.didSelectAddOption(.userDefined))
+					}, label: {
+						ZStack {
+							Circle()
+								.foregroundStyle(Color.clear)
+								.overlay(content: {
+									Circle()
+										.stroke(Color.accentTextColor, lineWidth: 2)
+								})
+							Text("직접\n추가하기")
 								.font(.defaultMidiumFont(.title))
-						})
-						.tint(.accentTextColor)
-						.buttonStyle(.bordered)
-						Spacer()
-					}
-					Spacer()
+								.tint(.accentTextColor)
+						}
+					})
 				}
+				.padding(20)
 			}
 		}
 	}
+}
+
+#Preview {
+	AddOptionView(store: Store(initialState: AddQuestionFeature.State(category: ""), reducer: { AddQuestionFeature() }))
 }

--- a/Selterview/Selterview/Sources/Presentation/Main/View/AddOptionView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/AddOptionView.swift
@@ -9,38 +9,40 @@ import SwiftUI
 import ComposableArchitecture
 
 struct AddOptionView: View {
-	let viewStore: ViewStoreOf<AddQuestionFeature>
+	let store: StoreOf<AddQuestionFeature>
 	
 	var body: some View {
-		GeometryReader { geometry in
-			let totalPadding: CGFloat = 150
-			let squareSize = max((geometry.size.width - totalPadding) / 2, 50)
-			VStack {
-				Spacer()
-				HStack {
+		WithViewStore(store, observe: \.self) { viewStore in
+			GeometryReader { geometry in
+				let totalPadding: CGFloat = 150
+				let squareSize = max((geometry.size.width - totalPadding) / 2, 50)
+				VStack {
 					Spacer()
-					Button(action: {
-						viewStore.send(.didSelectAddOption(.url))
-					}, label: {
-						Text("링크로 추가하기")
-							.frame(width: squareSize, height: squareSize)
-							.font(.defaultMidiumFont(.title))
-					})
-					.tint(.accentTextColor)
-					.buttonStyle(.bordered)
-					Spacer()
-					Button(action: {
-						viewStore.send(.didSelectAddOption(.userDefined))
-					}, label: {
-						Text("직접 추가하기")
-							.frame(width: squareSize, height: squareSize)
-							.font(.defaultMidiumFont(.title))
-					})
-					.tint(.accentTextColor)
-					.buttonStyle(.bordered)
+					HStack {
+						Spacer()
+						Button(action: {
+							viewStore.send(.didSelectAddOption(.url))
+						}, label: {
+							Text("링크로 추가하기")
+								.frame(width: squareSize, height: squareSize)
+								.font(.defaultMidiumFont(.title))
+						})
+						.tint(.accentTextColor)
+						.buttonStyle(.bordered)
+						Spacer()
+						Button(action: {
+							viewStore.send(.didSelectAddOption(.userDefined))
+						}, label: {
+							Text("직접 추가하기")
+								.frame(width: squareSize, height: squareSize)
+								.font(.defaultMidiumFont(.title))
+						})
+						.tint(.accentTextColor)
+						.buttonStyle(.bordered)
+						Spacer()
+					}
 					Spacer()
 				}
-				Spacer()
 			}
 		}
 	}

--- a/Selterview/Selterview/Sources/Presentation/Main/View/AddOptionView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/AddOptionView.swift
@@ -20,7 +20,7 @@ struct AddOptionView: View {
 					}, label: {
 						ZStack {
 							Circle()
-								.foregroundStyle(Color.clear)
+								.foregroundStyle(Color(.systemBackground))
 								.overlay(content: {
 									Circle()
 										.stroke(Color.accentTextColor, lineWidth: 2)
@@ -35,7 +35,7 @@ struct AddOptionView: View {
 					}, label: {
 						ZStack {
 							Circle()
-								.foregroundStyle(Color.clear)
+								.foregroundStyle(Color(.systemBackground))
 								.overlay(content: {
 									Circle()
 										.stroke(Color.accentTextColor, lineWidth: 2)

--- a/Selterview/Selterview/Sources/Presentation/Main/View/AddQuestionView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/AddQuestionView.swift
@@ -12,7 +12,7 @@ struct AddQuestionView: View {
 	let store: StoreOf<AddQuestionFeature>
 	
 	var body: some View {
-		WithViewStore(store, observe: { $0 }) { viewStore in
+		WithViewStore(store, observe: \.self) { viewStore in
 			VStack {
 				HStack {
 					Text(viewStore.category)
@@ -32,11 +32,11 @@ struct AddQuestionView: View {
 				}
 				Spacer()
 				if viewStore.additionalOption == .none {
-					AddOptionView(viewStore: viewStore)
+					AddOptionView(store: store)
 				} else if viewStore.additionalOption == .url {
-					URLAddView(viewStore: viewStore)
+					URLAddView(store: store)
 				} else {
-					UserDefineAddView(viewStore: viewStore)
+					UserDefineAddView(store: store)
 				}
 				Spacer()
 			}

--- a/Selterview/Selterview/Sources/Presentation/Main/View/AddQuestionView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/AddQuestionView.swift
@@ -44,3 +44,7 @@ struct AddQuestionView: View {
 		.padding(.horizontal, 20)
 	}
 }
+
+#Preview {
+	AddQuestionView(store: Store(initialState: AddQuestionFeature.State(category: ""), reducer: { AddQuestionFeature() }))
+}

--- a/Selterview/Selterview/Sources/Presentation/Main/View/AddQuestionView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/AddQuestionView.swift
@@ -17,7 +17,6 @@ struct AddQuestionView: View {
 				HStack {
 					Text(viewStore.category)
 						.font(Font.defaultBoldFont(.title))
-						.padding(.vertical, 20)
 					Spacer()
 					Button(action: {
 						viewStore.send(.addQuestionCancel)
@@ -30,6 +29,7 @@ struct AddQuestionView: View {
 						Text("완료")
 					})
 				}
+				.padding(.vertical, 20)
 				Spacer()
 				if viewStore.additionalOption == .none {
 					AddOptionView(store: store)

--- a/Selterview/Selterview/Sources/Presentation/Main/View/DetailCategoryView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/DetailCategoryView.swift
@@ -73,6 +73,7 @@ private struct HeaderView: View {
 				)
 			) { addQuestionStore in
 				AddQuestionView(store: addQuestionStore)
+					.background(Color(.systemGray6))
 			}
 		}
 	}

--- a/Selterview/Selterview/Sources/Presentation/Main/View/MainView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/MainView.swift
@@ -76,27 +76,19 @@ private struct BodyView: View {
 			LazyVGrid(columns: [GridItem(.flexible())]) {
 				ForEach(viewStore.categories.indices, id: \.self) { index in
 					NavigationLink(value: index) {
-						VStack(alignment: .leading) {
+						VStack(alignment: .center, spacing: 10) {
 							Text(viewStore.categories[index])
 								.font(Font.defaultMidiumFont(.title))
-								.padding(10)
 							Text("\(viewStore.questions[viewStore.categories[index]]?.count ?? 0)문제")
-								.foregroundStyle(Color.gray)
-								.padding(.leading, 10)
-							Spacer()
 						}
+						.padding(10)
 						.roundedStyle(
 							alignment: .topLeading,
-							maxWidth: .infinity,
-							minHeight: 100,
-							maxHeight: 200,
 							radius: 20,
 							font: .defaultLightFont(.body),
-							foregroundColor: .black,
-							backgroundColor: .clear,
-							borderColor: .accentTextColor
+							foregroundColor: Color(.systemBackground),
+							backgroundColor: .secondary
 						)
-						.padding(10)
 					}
 				}
 			}

--- a/Selterview/Selterview/Sources/Presentation/Main/View/MainView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/MainView.swift
@@ -34,6 +34,7 @@ struct MainView: View {
 						.showErrorMessage(showAlert: viewStore.$isError, message: viewStore.error?.errorDescription ?? "알 수 없는 문제가 발생했습니다.")
 						.showToastView(isShowToast: viewStore.$isShowToast, message: viewStore.$toastMessage)
 				}
+				.background(Color(.systemGray6))
 				.navigationDestination(for: Int.self) { index in
 					DetailCategoryView(store: Store(
 						initialState: DetailCategoryFeature.State(
@@ -59,12 +60,12 @@ private struct HeaderView: View {
 			Button {
 				viewStore.send(.addCategoryTapped)
 			} label: {
-				Image(systemName: "plus.circle.fill")
+				Image(systemName: "plus")
 					.foregroundStyle(Color.accentTextColor)
 					.font(.system(size: 40))
 			}
 		}
-		.padding([.leading, .trailing], 20)
+		.padding(20)
 	}
 }
 
@@ -86,8 +87,8 @@ private struct BodyView: View {
 							alignment: .topLeading,
 							radius: 20,
 							font: .defaultLightFont(.body),
-							foregroundColor: Color(.systemBackground),
-							backgroundColor: .secondary
+							foregroundColor: .primary,
+							backgroundColor: Color(.systemBackground)
 						)
 					}
 				}

--- a/Selterview/Selterview/Sources/Presentation/Main/View/URLAddView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/URLAddView.swift
@@ -20,7 +20,7 @@ struct URLAddView: View {
 				} else if viewStore.addQuestions.isEmpty {
 					VStack {
 						TextField("여기에 링크를 입력해주세요.", text: viewStore.$urlString)
-							.roundedStyle(backgroundColor: .backgroundLightGray.opacity(0.5))
+							.roundedStyle(backgroundColor: Color(.systemBackground))
 						Button(action: {
 							viewStore.send(.extractTextFromURL)
 						}, label: {

--- a/Selterview/Selterview/Sources/Presentation/Main/View/URLAddView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/URLAddView.swift
@@ -18,18 +18,19 @@ struct URLAddView: View {
 					ProgressView("추출 중...")
 						.progressViewStyle(CircularProgressViewStyle())
 				} else if viewStore.addQuestions.isEmpty {
-					VStack(spacing: 20) {
-						TextField(text: viewStore.$urlString, label: {
-							Text("여기에 링크를 입력해주세요.")
-						})
-						.roundedStyle(maxWidth: .infinity, maxHeight: 50, font: .title3, backgroundColor: .backgroundLightGray)
+					VStack {
+						TextField("여기에 링크를 입력해주세요.", text: viewStore.$urlString)
+							.roundedStyle(backgroundColor: .backgroundLightGray.opacity(0.5))
 						Button(action: {
 							viewStore.send(.extractTextFromURL)
 						}, label: {
 							Text("변환하기")
+								.tint(.accentTextColor)
 						})
-						.roundedStyle(maxWidth: .infinity, maxHeight: 50, backgroundColor: .buttonBackgroundColor)
+						.roundedStyle(backgroundColor: .white, borderColor: .borderColor)
 					}
+					.fixedSize(horizontal: false, vertical: true)
+					.padding()
 				} else {
 					ScrollView {
 						LazyVStack(spacing: 16) {
@@ -62,4 +63,8 @@ struct URLAddView: View {
 			}
 		}
 	}
+}
+
+#Preview {
+	URLAddView(store: Store(initialState: AddQuestionFeature.State(category: ""), reducer: { AddQuestionFeature() }))
 }

--- a/Selterview/Selterview/Sources/Presentation/Main/View/URLAddView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/URLAddView.swift
@@ -9,48 +9,50 @@ import SwiftUI
 import ComposableArchitecture
 
 struct URLAddView: View {
-	let viewStore: ViewStoreOf<AddQuestionFeature>
+	let store: StoreOf<AddQuestionFeature>
 	
 	var body: some View {
-		ZStack {
-			if viewStore.isExtracting {
-				ProgressView("추출 중...")
-					.progressViewStyle(CircularProgressViewStyle())
-			} else if viewStore.addQuestions.isEmpty {
-				VStack(spacing: 20) {
-					TextField(text: viewStore.$urlString, label: {
-						Text("여기에 링크를 입력해주세요.")
-					})
-					.roundedStyle(maxWidth: .infinity, maxHeight: 50, font: .title3, backgroundColor: .backgroundLightGray)
-					Button(action: {
-						viewStore.send(.extractTextFromURL)
-					}, label: {
-						Text("변환하기")
-					})
-					.roundedStyle(maxWidth: .infinity, maxHeight: 50, backgroundColor: .buttonBackgroundColor)
-				}
-			} else {
-				ScrollView {
-					LazyVStack(spacing: 16) {
-						ForEach(viewStore.addQuestions.indices, id: \.self) { index in
-							HStack {
-								TextEditor(text: viewStore.binding(
-									get: { $0.addQuestions[index].title },
-									send: { .updateQuestionTitle(index, $0) }
-								))
-								.frame(minHeight: 80)
-								.overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.5)))
+		WithViewStore(store, observe: \.self) { viewStore in
+			ZStack {
+				if viewStore.isExtracting {
+					ProgressView("추출 중...")
+						.progressViewStyle(CircularProgressViewStyle())
+				} else if viewStore.addQuestions.isEmpty {
+					VStack(spacing: 20) {
+						TextField(text: viewStore.$urlString, label: {
+							Text("여기에 링크를 입력해주세요.")
+						})
+						.roundedStyle(maxWidth: .infinity, maxHeight: 50, font: .title3, backgroundColor: .backgroundLightGray)
+						Button(action: {
+							viewStore.send(.extractTextFromURL)
+						}, label: {
+							Text("변환하기")
+						})
+						.roundedStyle(maxWidth: .infinity, maxHeight: 50, backgroundColor: .buttonBackgroundColor)
+					}
+				} else {
+					ScrollView {
+						LazyVStack(spacing: 16) {
+							ForEach(viewStore.addQuestions.indices, id: \.self) { index in
 								HStack {
-									Button {
-										viewStore.send(.deleteQuestion(index))
-									} label: {
-										Image(systemName: "trash")
-											.foregroundColor(.red)
-									}
-									Button {
-										viewStore.send(.addEmptyQuestion(index))
-									} label: {
-										Image(systemName: "plus")
+									TextEditor(text: viewStore.binding(
+										get: { $0.addQuestions[index].title },
+										send: { .updateQuestionTitle(index, $0) }
+									))
+									.frame(minHeight: 80)
+									.overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.5)))
+									HStack {
+										Button {
+											viewStore.send(.deleteQuestion(index))
+										} label: {
+											Image(systemName: "trash")
+												.foregroundColor(.red)
+										}
+										Button {
+											viewStore.send(.addEmptyQuestion(index))
+										} label: {
+											Image(systemName: "plus")
+										}
 									}
 								}
 							}

--- a/Selterview/Selterview/Sources/Presentation/Main/View/UserDefineAddView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/UserDefineAddView.swift
@@ -9,38 +9,40 @@ import SwiftUI
 import ComposableArchitecture
 
 struct UserDefineAddView: View {
-	let viewStore: ViewStoreOf<AddQuestionFeature>
+	let store: StoreOf<AddQuestionFeature>
 	
 	var body: some View {
-		ScrollView {
-			LazyVStack(spacing: 16) {
-				ForEach(viewStore.addQuestions.indices, id: \.self) { index in
-					HStack {
-						TextEditor(text: viewStore.binding(
-							get: { $0.addQuestions[index].title },
-							send: { .updateQuestionTitle(index, $0) }
-						))
-						.frame(minHeight: 80)
-						.overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.5)))
+		WithViewStore(store, observe: \.self) { viewStore in
+			ScrollView {
+				LazyVStack(spacing: 16) {
+					ForEach(viewStore.addQuestions.indices, id: \.self) { index in
 						HStack {
-							Button {
-								viewStore.send(.deleteQuestion(index))
-							} label: {
-								Image(systemName: "trash")
-									.foregroundColor(.red)
-							}
-							Button {
-								viewStore.send(.addEmptyQuestion(index))
-							} label: {
-								Image(systemName: "plus")
+							TextEditor(text: viewStore.binding(
+								get: { $0.addQuestions[index].title },
+								send: { .updateQuestionTitle(index, $0) }
+							))
+							.frame(minHeight: 80)
+							.overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.5)))
+							HStack {
+								Button {
+									viewStore.send(.deleteQuestion(index))
+								} label: {
+									Image(systemName: "trash")
+										.foregroundColor(.red)
+								}
+								Button {
+									viewStore.send(.addEmptyQuestion(index))
+								} label: {
+									Image(systemName: "plus")
+								}
 							}
 						}
 					}
 				}
 			}
-		}
-		.onAppear() {
-			viewStore.send(.addFirstQuestion)
+			.onAppear() {
+				viewStore.send(.addFirstQuestion)
+			}
 		}
 	}
 }

--- a/Selterview/Selterview/Sources/Presentation/Main/View/UserDefineAddView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/UserDefineAddView.swift
@@ -37,7 +37,7 @@ struct UserDefineAddView: View {
 									.font(.system(size: 24))
 							}
 						}
-						.padding(.horizontal, 20)
+						.padding(1)
 					}
 				}
 			}

--- a/Selterview/Selterview/Sources/Presentation/Main/View/UserDefineAddView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/UserDefineAddView.swift
@@ -16,27 +16,28 @@ struct UserDefineAddView: View {
 			ScrollView {
 				LazyVStack(spacing: 16) {
 					ForEach(viewStore.addQuestions.indices, id: \.self) { index in
-						HStack {
+						HStack(spacing: 16) {
+							Button {
+								viewStore.send(.deleteQuestion(index))
+							} label: {
+								Image(systemName: "trash")
+									.foregroundColor(.red)
+									.font(.system(size: 24))
+							}
 							TextEditor(text: viewStore.binding(
 								get: { $0.addQuestions[index].title },
 								send: { .updateQuestionTitle(index, $0) }
 							))
 							.frame(minHeight: 80)
-							.overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.5)))
-							HStack {
-								Button {
-									viewStore.send(.deleteQuestion(index))
-								} label: {
-									Image(systemName: "trash")
-										.foregroundColor(.red)
-								}
-								Button {
-									viewStore.send(.addEmptyQuestion(index))
-								} label: {
-									Image(systemName: "plus")
-								}
+							.overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.borderColor))
+							Button {
+								viewStore.send(.addEmptyQuestion(index))
+							} label: {
+								Image(systemName: "plus")
+									.font(.system(size: 24))
 							}
 						}
+						.padding(.horizontal, 20)
 					}
 				}
 			}
@@ -45,4 +46,8 @@ struct UserDefineAddView: View {
 			}
 		}
 	}
+}
+
+#Preview {
+	UserDefineAddView(store: Store(initialState: AddQuestionFeature.State(category: ""), reducer: { AddQuestionFeature() }))
 }

--- a/Selterview/Selterview/Sources/Presentation/Problem/View/DetailQuestionView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Problem/View/DetailQuestionView.swift
@@ -32,9 +32,6 @@ struct DetailQuestionView: View {
 			}
 			.roundedStyle(
 				alignment: .topLeading,
-				maxWidth: .infinity,
-				minHeight: 200,
-				maxHeight: .infinity,
 				radius: 20,
 				font: .defaultMidiumFont(.body),
 				foregroundColor: .black,

--- a/Selterview/Selterview/Sources/Presentation/Problem/View/ProblemView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Problem/View/ProblemView.swift
@@ -18,7 +18,7 @@ struct ProblemView: View {
 			ZStack(alignment: .topTrailing) {
 				VStack {
 					QuestionCard(isTailQuestionCreating: viewStore.$isTailQuestionCreating, question: viewStore.question)
-						.animation(.easeIn, value: viewStore.question)
+						.animation(.easeInOut, value: viewStore.question)
 						.onTapGesture {
 							viewStore.send(.stopSpeak)
 							if viewStore.isTailQuestionCreating == false {
@@ -79,6 +79,7 @@ struct ProblemView: View {
 			}
 			.fullScreenCover(isPresented: viewStore.$isSpeech) {
 				SpeechView(isSpeech: viewStore.$isSpeech, store: self.store.scope(state: \.speechState, action: \.speechAction))
+					.frame(width: 150, height: 150, alignment: .center)
 					.clearBackground()
 			}
 			.gesture(
@@ -114,7 +115,7 @@ private struct FooterView: View {
 				}
 				viewStore.send(.newTailQuestionCreateButtonTapped)
 			}
-			.roundedStyle(font: .defaultMidiumFont(.title3), backgroundColor: .buttonBackgroundColor)
+			.roundedStyle(font: .defaultMidiumFont(.title3), foregroundColor: .primary, backgroundColor: Color(.systemBackground), borderColor: .accentTextColor)
 			Spacer()
 			Button {
 				viewStore.send(.startSpeechButtonTapped)
@@ -122,7 +123,7 @@ private struct FooterView: View {
 				Image(systemName: "mic")
 					.symbolRenderingMode(.monochrome)
 			}
-			.roundedStyle(radius: 25, backgroundColor: .textBackgroundLightPurple)
+			.roundedStyle(radius: 25, foregroundColor: Color(.systemBackground), backgroundColor: .textBackgroundLightPurple)
 			Spacer()
 			Button("다음질문") {
 				viewStore.send(.stopSpeak)
@@ -131,8 +132,9 @@ private struct FooterView: View {
 				}
 				viewStore.send(.nextQuestionButtonTapped)
 			}
-			.roundedStyle(font: .defaultMidiumFont(.title3), backgroundColor: .buttonBackgroundColor)
+			.roundedStyle(font: .defaultMidiumFont(.title3), foregroundColor: .primary, backgroundColor: Color(.systemBackground), borderColor: .accentTextColor)
 			Spacer()
 		}
+		.frame(height: 50)
 	}
 }

--- a/Selterview/Selterview/Sources/Presentation/Problem/View/ProblemView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Problem/View/ProblemView.swift
@@ -28,9 +28,6 @@ struct ProblemView: View {
 					AnswerView(answerText: viewStore.$answerText, isFocused: _isFocused)
 						.roundedStyle(
 							alignment: .topLeading,
-							maxWidth: .infinity,
-							minHeight: 100,
-							maxHeight: .infinity,
 							radius: 20,
 							font: .defaultLightFont(.body),
 							foregroundColor: .black,
@@ -117,7 +114,7 @@ private struct FooterView: View {
 				}
 				viewStore.send(.newTailQuestionCreateButtonTapped)
 			}
-			.roundedStyle(maxWidth: 150, maxHeight: 50, font: .defaultMidiumFont(.title3), backgroundColor: .buttonBackgroundColor)
+			.roundedStyle(font: .defaultMidiumFont(.title3), backgroundColor: .buttonBackgroundColor)
 			Spacer()
 			Button {
 				viewStore.send(.startSpeechButtonTapped)
@@ -125,7 +122,7 @@ private struct FooterView: View {
 				Image(systemName: "mic")
 					.symbolRenderingMode(.monochrome)
 			}
-			.roundedStyle(maxWidth: 50, maxHeight: 50, radius: 25, backgroundColor: .textBackgroundLightPurple)
+			.roundedStyle(radius: 25, backgroundColor: .textBackgroundLightPurple)
 			Spacer()
 			Button("다음질문") {
 				viewStore.send(.stopSpeak)
@@ -134,7 +131,7 @@ private struct FooterView: View {
 				}
 				viewStore.send(.nextQuestionButtonTapped)
 			}
-			.roundedStyle(maxWidth: 150, maxHeight: 50, font: .defaultMidiumFont(.title3), backgroundColor: .buttonBackgroundColor)
+			.roundedStyle(font: .defaultMidiumFont(.title3), backgroundColor: .buttonBackgroundColor)
 			Spacer()
 		}
 	}

--- a/Selterview/Selterview/Sources/Presentation/Problem/View/QuestionCard.swift
+++ b/Selterview/Selterview/Sources/Presentation/Problem/View/QuestionCard.swift
@@ -17,9 +17,6 @@ struct QuestionCard: View {
 			.opacity(isTailQuestionCreating ? 0.3 : 1)
 			.roundedStyle(
 				alignment: .topLeading,
-				maxWidth: .infinity,
-				minHeight: 100,
-				maxHeight: 200,
 				radius: 20,
 				font: .defaultMidiumFont(.body),
 				foregroundColor: .black,

--- a/Selterview/Selterview/Sources/Presentation/Problem/View/QuestionCard.swift
+++ b/Selterview/Selterview/Sources/Presentation/Problem/View/QuestionCard.swift
@@ -12,18 +12,20 @@ struct QuestionCard: View {
 	var question: QuestionDTO
 	
 	var body: some View {
-		Text(isTailQuestionCreating ? "질문을 생성하고 있습니다." : "질문:\n\(question.title)")
-			.lineSpacing(5)
-			.opacity(isTailQuestionCreating ? 0.3 : 1)
-			.roundedStyle(
-				alignment: .topLeading,
-				radius: 20,
-				font: .defaultMidiumFont(.body),
-				foregroundColor: .black,
-				backgroundColor: .clear,
-				borderColor: .accentTextColor
-			)
-			.padding(.bottom, 20)
-			.showLoadingView(isLoading: $isTailQuestionCreating)
+		VStack {
+			if !isTailQuestionCreating {
+				Text("\(question.title)")
+					.lineSpacing(5)
+			}
+		}
+		.roundedStyle(
+			alignment: .topLeading,
+			radius: 20,
+			font: .defaultMidiumFont(.body),
+			foregroundColor: .black,
+			backgroundColor: .clear,
+			borderColor: .accentTextColor
+		)
+		.showLoadingView(isLoading: $isTailQuestionCreating, loadingMassage: "질문을 생성하는 중입니다.")
 	}
 }

--- a/Selterview/Selterview/Sources/Presentation/Problem/View/SpeechView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Problem/View/SpeechView.swift
@@ -33,7 +33,7 @@ struct SpeechView: View {
 					}
 					.padding([.bottom, .leading, .trailing])
 				}
-				.roundedStyle(maxWidth: 150, maxHeight: 150, font: .defaultMidiumFont(.title2), backgroundColor: .lightPurple)
+				.roundedStyle(font: .defaultMidiumFont(.title2), backgroundColor: .lightPurple)
 			}
 			.onAppear {
 				viewStore.send(.startSpeech)


### PR DESCRIPTION
## 🔖 개요
- 버전: v1.3.0
- 목적: 전체적인 앱의 UI 디자인 변경

## ✨ 주요 변경 사항
### MainView
전
<img src="https://github.com/user-attachments/assets/3fc8fd03-a38e-4cdd-a74f-c710946c5a09" alt="MainView" width="150"/>
후
<img src="https://github.com/user-attachments/assets/dff262f0-64bd-44fa-92a0-17b4895432cf" alt="MainView" width="150"/>

- 배경 색상과 카드 색상의 차이를 활용하여 가독성 향상 목적

### ProblemView
전
<img src="https://github.com/user-attachments/assets/e7acccd6-f854-4981-b7b4-0749338252c2" alt="ProblemView" width="150"/>
후
<img src="https://github.com/user-attachments/assets/f692a285-7d8c-40c4-bc17-18aae3873d2e" alt="ProblemView" width="150"/>

- 재사용을 위한 RoundedRectangle Modifier를 더 자유롭고 범용성 있게 활용할 수 있도록 수정

### AddQuestionView
전
<img src="https://github.com/user-attachments/assets/f71a9cb5-ea40-4f32-bd57-8a23242b3e27" alt="AddQuestionView" width="150"/>
후
<img src="https://github.com/user-attachments/assets/68fd3790-19b2-43bc-9d3c-d5410ecc1911" alt="AddQuestionView" width="150"/>

- 기존 모호한 색상 구분과 작은 텍스트필드와 큰 글씨 등으로 인한 가독성 저해 요소를 수정하여 가독성을 향상 시킴.

## 🧪 테스트 결과
- Xcode Cloud Build Test: 성공적으로 완료