### PR TITLE
[✨Feat] 메인뷰에 카테고리 삭제 기능 추가

### DIFF
--- a/Selterview/Selterview/Sources/Presentation/Main/MainFeature.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/MainFeature.swift
@@ -27,6 +27,7 @@ struct MainFeature {
 		case addCategoryTapped
 		case addCategory
 		case addCategoryCancel
+		case deleteCategory(String)
 		case catchError(RealmFailure)
 		case binding(BindingAction<State>)
 	}
@@ -72,6 +73,11 @@ struct MainFeature {
 				state.addCategoryText = ""
 				state.isCategoryAddButtonTap = false
 				return .none
+			case .deleteCategory(let category):
+				var categories = UserDefaults.standard.array(forKey: "Categories") as? [String] ?? []
+				categories.removeAll { $0 == category }
+				UserDefaults.standard.set(categories, forKey: "Categories")
+				return .concatenate(.send(.fetchCategories))
 			case .catchError(let error):
 				state.isError = true
 				state.toastMessage = error.errorDescription ?? "알 수 없는 에러가 발생했습니다."

--- a/Selterview/Selterview/Sources/Presentation/Main/View/MainView.swift
+++ b/Selterview/Selterview/Sources/Presentation/Main/View/MainView.swift
@@ -91,6 +91,13 @@ private struct BodyView: View {
 							backgroundColor: Color(.systemBackground)
 						)
 					}
+					.contextMenu {
+						Button(role: .destructive) {
+							viewStore.send(.deleteCategory(viewStore.categories[index]))
+						} label: {
+							Label("삭제", systemImage: "trash")
+						}
+					}
 				}
 			}
 			.padding(.horizontal)


### PR DESCRIPTION
## 🔖 개요
- 버전: v1.3.0
- 목적: 메인뷰에 카테고리 삭제 기능 추가

## ✨ 주요 기능
### MainView
<img src="https://github.com/user-attachments/assets/d0e28069-5e0e-4a35-90ad-1bfb1b515e47" alt="MainView" width="150"/>

- 카테고리를 길게 터치하면 삭제 버튼이 나타나고 해당 삭제 버튼 클릭 시 카테고리 삭제 기능 구현

## 🧪 테스트 결과
- Xcode Cloud Build Test: 성공적으로 완료